### PR TITLE
Use sudo for aptly calls in not_if and only_if

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,22 @@
+module ::Aptly
+  def aptly(command)
+    "sudo -u #{node['aptly']['user']} -i -- aptly #{command}"
+  end
+
+  def snapshot_list
+    aptly('snapshot -raw list')
+  end
+
+  def mirror_list
+    aptly('mirror -raw list')
+  end
+
+  def repo_list
+    aptly('repo -raw list')
+  end
+
+  def publish_list
+    aptly('publish list')
+  end
+
+end

--- a/providers/publish.rb
+++ b/providers/publish.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+include ::Aptly
+
 use_inline_resources if defined?(use_inline_resources)
 
 def whyrun_supported?
@@ -30,12 +32,12 @@ action :create do
     user node['aptly']['user']
     group node['aptly']['group']
     environment environment
-    not_if %{ aptly publish list | grep #{new_resource.name} }
+    not_if "#{publish_list} | grep #{new_resource.name}"
   end
 end
 
 action :update do
-  environment = { "HOME" => "#{node['aptly']['rootdir']}" }
+  environment = { "HOME" => node['aptly']['rootdir'] }
   execute "Updating distribution - #{new_resource.prefix} #{new_resource.name}" do
     command "aptly publish update #{new_resource.name} #{new_resource.prefix}"
     user node['aptly']['user']
@@ -49,6 +51,6 @@ action :drop do
     command "aptly publish drop #{new_resource.name} #{new_resource.prefix}"
     user node['aptly']['user']
     group node['aptly']['group']
-    only_if %{ aptly publish list | grep #{new_resource.name} }
+    only_if "#{publish_list} | grep #{new_resource.name}"
   end
 end

--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+include ::Aptly
+
 use_inline_resources if defined?(use_inline_resources)
 
 def whyrun_supported?
@@ -32,7 +34,7 @@ action :create do
     end
     user node['aptly']['user']
     group node['aptly']['group']
-    not_if %{ aptly repo list --raw | grep #{new_resource.name} }
+    not_if "#{repo_list} | grep #{new_resource.name}"
   end
 end
 
@@ -41,7 +43,7 @@ action :drop do
     command "aptly repo drop #{new_resource.name}"
     user node['aptly']['user']
     group node['aptly']['group']
-    only_if %{ aptly repo list --raw | grep #{new_resource.name} }
+    only_if "#{repo_list} | grep #{new_resource.name}"
   end
 end
 
@@ -64,7 +66,7 @@ action :add do
         command "aptly repo add #{new_resource.name} #{new_resource.file}"
         user node['aptly']['user']
         group node['aptly']['group']
-        not_if %{ aptly repo show -with-packages #{new_resource.name} | grep #{pk} }
+        not_if "#{aptly('repo show -with-packages')} #{new_resource.name} | grep #{pk}"
       end
     else
       Chef::Log.info "#{new_resource.file} does not exist"
@@ -75,12 +77,11 @@ action :add do
 end
 
 action :remove do
-  pkg = ::File.basename("#{new_resource.file}").split('.').first
+  pkg = ::File.basename(new_resource.file).split('.').first
   execute "Removing Package - #{new_resource.file}" do
     command "aptly repo remove #{new_resource.name} #{pkg}"
     user node['aptly']['user']
     group node['aptly']['group']
-    only_if %{ aptly repo show -with-packages #{new_resource.name} | grep #{pkg} }
+    only_if "#{aptly('repo show -with-packages')} #{new_resource.name} | grep #{pk}"
   end
 end
-

--- a/providers/snapshot.rb
+++ b/providers/snapshot.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+include ::Aptly
+
 use_inline_resources if defined?(use_inline_resources)
 
 def whyrun_supported?
@@ -29,14 +31,14 @@ action :create do
       command "aptly snapshot create #{new_resource.name} empty"
       user node['aptly']['user']
       group node['aptly']['group']
-      not_if %{ aptly snapshot -raw list | grep #{new_resource.name} }
+      not_if "#{snapshot_list} | grep #{new_resource.name}"
     end
   else
     execute "Creating Snapshot - #{new_resource.name}" do
       command "aptly snapshot create #{new_resource.name} from #{new_resource.type} #{new_resource.from}"
       user node['aptly']['user']
       group node['aptly']['group']
-      not_if %{ aptly snapshot -raw list | grep #{new_resource.name} }
+      not_if "#{snapshot_list} | grep #{new_resource.name}"
     end
   end
 end
@@ -46,7 +48,7 @@ action :verify do
     command "aptly snapshot verify #{new_resource.name}"
     user node['aptly']['user']
     group node['aptly']['group']
-    only_if %{ aptly snapshot -raw list | grep #{new_resource.name} }
+    only_if "#{snapshot_list} | grep #{new_resource.name}"
   end
 end
 
@@ -55,7 +57,7 @@ action :pull do
     command "aptly snapshot pull -no-deps=#{new_resource.deps} -no-remove=#{new_resource.remove} #{new_resource.resource} #{new_resource.source} #{new_resource.name} #{new_resource.package}"
     user node['aptly']['user']
     group node['aptly']['group']
-    not_if %{ aptly snapshot -raw list | grep #{new_resource.name} }
+    not_if "#{snapshot_list} | grep #{new_resource.name}"
   end
 end
 
@@ -64,7 +66,7 @@ action :merge do
     command "aptly snapshot merge #{new_resource.name} #{new_resource.merge_source1} #{new_resource.merge_source2}"
     user node['aptly']['user']
     group node['aptly']['group']
-    not_if %{ aptly snapshot -raw list | grep #{new_resource.name} }
+    not_if "#{snapshot_list} | grep #{new_resource.name}"
   end
 end
 
@@ -73,6 +75,6 @@ action :drop do
     command "aptly snapshot drop #{new_resource.name}"
     user node['aptly']['user']
     group node['aptly']['group']
-    only_if %{ aptly snapshot -raw list | grep #{new_resource.name} }
+    only_if "#{snapshot_list} | grep #{new_resource.name}"
   end
 end


### PR DESCRIPTION
Without this, the conditions will always fail (and thus trigger or inhibit respectively), since for the root user, there's no ~/.aptly.conf.

Importing a dependency on sudo functioning properly imports some possible headaches on different platforms, but seems like a reasonable fix nonetheless.
