### PR TITLE
Support key imports from file.

### DIFF
--- a/resources/mirror.rb
+++ b/resources/mirror.rb
@@ -32,3 +32,4 @@ attribute :distribution, :kind_of => String, :default => nil
 attribute :uri, :kind_of => String, :default => nil
 attribute :keyid, :kind_of => String, :default => nil
 attribute :keyserver, :kind_of => String, :default => nil
+attribute :keyfile, :kind_of => String, :default => nil


### PR DESCRIPTION
Hi,
thanks for sharing this cookbook, very useful!

When adding a remote repo as mirror, the signing key had to be downloaded from a keyserver, which would sometimes fail. With this patch, recipes can include a copy of the key in a file and use this instead:

aptly_mirror "haproxy-wheezy-backports" do
  action :create
  distribution "wheezy-backports"
  component "main"
  keyfile "haproxy-backports-signing-key.asc"
  uri "http://haproxy.debian.net/"
end

The file haproxy-backports-signing-key.asc should be located in files/default in the cookbook.
