### PR TITLE
repo_add remove_files hack

### DIFF
--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -56,11 +56,13 @@ action :add do
       execute "Adding packages from #{new_resource.directory}" do
         if new_resource.remove_files
           command "aptly repo add -remove-files #{repo_name} #{new_resource.directory}"
+          user 'root'
+          group 'root'
         else
           command "aptly repo add #{repo_name} #{new_resource.directory}"
+          user node['aptly']['user']
+          group node['aptly']['group']
         end
-        user node['aptly']['user']
-        group node['aptly']['group']
         environment aptly_env
       end
     else
@@ -96,4 +98,3 @@ action :remove do
     only_if %{ aptly repo show -with-packages #{repo_name} | grep #{pkg} }
   end
 end
-

--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -65,6 +65,13 @@ action :add do
         end
         environment aptly_env
       end
+      if new_resource.remove_files
+        execute "Fix up DB and Pool permissions" do
+          command "chown -R #{node['aptly']['user']}:#{node['aptly']['group']} #{node['aptly']['rootdir']}/db/* "\
+                  "&& "\
+                  "chown -R #{node['aptly']['user']}:#{node['aptly']['group']} #{node['aptly']['rootdir']}/pool/*"
+        end
+      end
     else
       Chef::Log.info "#{new_resource.directory} is not a valid directory"
     end


### PR DESCRIPTION
I believe that a bug in aptly that's causing this behavior and not the lwrp.

This patch just works around the aptly bug.  But will likely cause other issues as the newly written level db files as well as the log file end up being owned by root.

Using a resource like this example:

```
    # Add deb files from incoming to repository
    aptly_repo "my_test_repo" do
      action :add
      remove_files true
      directory "/var/repository/incoming/precise/test"
    end
```

Even when the files are set to 0666 and owner:group set to aptly like this:

```
/var/repository/incoming/precise/test# ls -las
total 36
 4 drwxrwsr-x 2 aptly aptly  4096 Jul 27 14:35 .
 4 drwxr-xr-x 6 aptly aptly  4096 Jul 27 01:08 ..
28 -rw-rw-rw- 1 aptly aptly 24600 Jul 27 14:35 foo-1.0.0_amd64.deb
```

The command
  `aptly repo add -remove-files my_test_repo /var/repository/incoming/precise/test` returns
  `ERROR: unable to remove file: remove /var/repository/incoming/precise/test/foo-1.0.0_amd64.deb: permission denied`

Running the command as root works as expected.
