### PR TITLE
Use exact matches in provider not_if checks

### DIFF
--- a/providers/mirror.rb
+++ b/providers/mirror.rb
@@ -56,7 +56,7 @@ action :create do
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env
-    not_if %{ aptly mirror -raw list | grep #{new_resource.name} }
+    not_if %{ aptly mirror -raw list | grep ^#{new_resource.name}$ }
   end
 end
 
@@ -66,7 +66,7 @@ action :update do
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env
-    only_if %{ aptly mirror -raw list | grep #{new_resource.name} }
+    only_if %{ aptly mirror -raw list | grep ^#{new_resource.name}$ }
   end
 end
 
@@ -76,7 +76,7 @@ action :drop do
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env
-    only_if %{ aptly mirror -raw list | grep #{new_resource.name} }
+    only_if %{ aptly mirror -raw list | grep ^#{new_resource.name}$ }
   end
 end
 

--- a/providers/publish.rb
+++ b/providers/publish.rb
@@ -29,7 +29,7 @@ action :create do
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env
-    not_if %{ aptly publish list | grep #{new_resource.name} }
+    not_if %{ aptly publish list | grep ^#{new_resource.name}$ }
   end
 end
 
@@ -47,7 +47,7 @@ action :drop do
     command "aptly publish drop #{new_resource.name} #{new_resource.prefix}"
     user node['aptly']['user']
     group node['aptly']['group']
-    only_if %{ aptly publish list | grep #{new_resource.name} }
+    only_if %{ aptly publish list | grep ^#{new_resource.name}$ }
     environment aptly_env
   end
 end

--- a/providers/snapshot.rb
+++ b/providers/snapshot.rb
@@ -30,7 +30,7 @@ action :create do
       user node['aptly']['user']
       group node['aptly']['group']
       environment aptly_env
-      not_if %{ aptly snapshot -raw list | grep #{new_resource.name} }
+      not_if %{ aptly snapshot -raw list | grep ^#{new_resource.name}$ }
     end
   else
     execute "Creating Snapshot - #{new_resource.name}" do
@@ -38,7 +38,7 @@ action :create do
       user node['aptly']['user']
       group node['aptly']['group']
       environment aptly_env
-      not_if %{ aptly snapshot -raw list | grep #{new_resource.name} }
+      not_if %{ aptly snapshot -raw list | grep ^#{new_resource.name}$ }
     end
   end
 end
@@ -49,7 +49,7 @@ action :verify do
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env
-    only_if %{ aptly snapshot -raw list | grep #{new_resource.name} }
+    only_if %{ aptly snapshot -raw list | grep ^#{new_resource.name}$ }
   end
 end
 
@@ -59,7 +59,7 @@ action :pull do
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env
-    not_if %{ aptly snapshot -raw list | grep #{new_resource.name} }
+    not_if %{ aptly snapshot -raw list | grep ^#{new_resource.name}$ }
   end
 end
 
@@ -69,7 +69,7 @@ action :merge do
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env
-    not_if %{ aptly snapshot -raw list | grep #{new_resource.name} }
+    not_if %{ aptly snapshot -raw list | grep ^#{new_resource.name}$ }
   end
 end
 
@@ -79,6 +79,6 @@ action :drop do
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env
-    only_if %{ aptly snapshot -raw list | grep #{new_resource.name} }
+    only_if %{ aptly snapshot -raw list | grep ^#{new_resource.name}$ }
   end
 end


### PR DESCRIPTION
Hi!

I just realized that some resource naming can skipped with not_if chef guard due partly matching of grep pipeline. I suggest use exact matching with ^$ for checking resource existence in my pr.

Maybe it's not best refined method, but can work for almost all cases. Nearly variant for this is -Fx for grep, but it may depends from different grep versions on various distributions.
