### PR TITLE
Add support for tarball installations

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,14 +10,16 @@ provisioner:
 platforms:
   - name: ubuntu-12.04
     driver_config:
-      box: ubuntu1204
       run_list:
         - recipe[apt]
   - name: ubuntu-14.04
     driver_config:
-      box: ubuntu1404
       run_list:
         - recipe[apt]
+  - name: centos-7.2
+    attributes:
+      aptly:
+        architectures: [amd64]
 
 suites:
   - name: default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,6 +4,23 @@ default['aptly']['components'] = ['main']
 default['aptly']['keyserver'] = 'keys.gnupg.net'
 default['aptly']['key'] = '9E3E53F19C7DE460'
 
+default['aptly']['tarball']['uri'] =
+  'https://bintray.com/artifact/download/smira/aptly/' \
+  'aptly_0.9.7_linux_amd64.tar.gz'
+
+default['aptly']['tarball']['checksum'] =
+  'ec877942783c7a24566c802120da51d4cecaf2c76d3151e1a4869da1ee0690f7'
+
+default['aptly']['tarball']['version'] =
+  begin
+    require 'uri'
+    filename =
+      ::File.basename(URI.parse(node['aptly']['tarball']['uri']).path)
+    /aptly_(.+?)_/.match(filename)[1]
+  rescue
+    1
+  end
+
 default['aptly']['user'] = 'aptly'
 default['aptly']['group'] = 'aptly'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,15 @@ description      'Installs/Configures aptly'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.9'
 
-supports "ubuntu"
-supports "debian"
+supports 'amazon'
+supports 'centos'
+supports 'debian'
+supports 'fedora'
+supports 'redhat'
+supports 'scientific'
+supports 'suse'
+supports 'ubuntu'
 
-depends "apt"
+depends 'apt'
+depends 'ark'
+

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -17,24 +17,16 @@
 # limitations under the License.
 #
 
-include_recipe "apt"
+if node[:platform_family] == 'debian'
+  include_recipe 'aptly::install_from_packages'
+else
+  include_recipe 'aptly::install_from_tarball'
+end
 
 environment = {
   "USER" => "#{node['aptly']['user']}",
   "HOME" => "#{node['aptly']['rootdir']}"
 }
-
-apt_repository "aptly" do
-  uri node['aptly']['uri']
-  distribution node['aptly']['dist']
-  components node['aptly']['components']
-  keyserver node['aptly']['keyserver']
-  key node['aptly']['key']
-  action :add
-end
-
-package "aptly"
-package "graphviz"
 
 group node['aptly']['group'] do
   action :create

--- a/recipes/install_from_packages.rb
+++ b/recipes/install_from_packages.rb
@@ -1,0 +1,32 @@
+#
+# Cookbook Name:: aptly
+# Recipe:: install_from_packages
+#
+# Copyright 2014, Heavy Water Operations, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'apt'
+
+apt_repository 'aptly' do
+  uri node['aptly']['uri']
+  distribution node['aptly']['dist']
+  components node['aptly']['components']
+  keyserver node['aptly']['keyserver']
+  key node['aptly']['key']
+  action :add
+end
+
+package 'aptly'
+package 'graphviz'

--- a/recipes/install_from_tarball.rb
+++ b/recipes/install_from_tarball.rb
@@ -1,0 +1,37 @@
+#
+# Cookbook Name:: aptly
+# Recipe:: install_from_tarball
+#
+# Copyright 2016, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ark 'aptly' do
+  url node['aptly']['tarball']['uri']
+  checksum node['aptly']['tarball']['checksum']
+  version node['aptly']['tarball']['version']
+  has_binaries ['aptly']
+  prefix_bin '/usr/bin'
+  prefix_root '/opt'
+  prefix_home '/opt'
+  action :install
+end
+
+if node[:platform_family] == 'fedora' ||
+   node[:platform_family] == 'rhel' ||
+   node[:platform_family] == 'suse' 
+ package 'graphviz'
+else
+  log 'Unknown platform family, not attempting graphviz install'
+end


### PR DESCRIPTION
I'm afraid I need to host aptly-based mirrors on non-Debian based operating systems.   Fortunately, Aptly upstream distributes Linux static binaries in tarballs.

This PR adds support for tarball-based installation, retaining the use of the existing configuration recipe and providers.
