### PR TITLE
add ability to use -filter-with-deps for mirror creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the aptly cookbook.
 ## Unreleased
 
 - Migrate to circleci for testing
+- add support for aptly mirror `-filter-with-deps` argument.
 
 ## v1.0.0 (24-10-2018)
 

--- a/README.md
+++ b/README.md
@@ -142,18 +142,18 @@ Manage external mirror
 
 #### Properties
 
-Name           | Types  | Description                                  | Default          | Used with...
--------------- | ------ | -------------------------------------------- | ---------------- | ------------
-`mirror_name`  | String | Mirror name                                  | <resource_name>  | all
-`component`    | String | Repository component                         | ''               | :create
-`distribution` | String | Name of distribution repository              | ''               | :create
-`uri`          | String | Uri of remote repository                     | ''               | :create
-`keyid`        | String | Remote repository key ID                     | ''               | :create
-`keyserver`    | String | Keys server                                  | 'keys.gnupg.net' | :create
-`cookbook`     | String | Cookbook name where you've store the keyfile | ''               | :create
-`keyfile`      | String | Key file name                                | ''               | :create
-`filter`       | String | Mirror filter                                | ''               | :creates
-
+Name               | Types         | Description                                  | Default          | Used with...
+------------------ | ------------- | -------------------------------------------- | ---------------- | ------------
+`mirror_name`      | String        | Mirror name                                  | <resource_name>  | all
+`component`        | String        | Repository component                         | ''               | :create
+`distribution`     | String        | Name of distribution repository              | ''               | :create
+`uri`              | String        | Uri of remote repository                     | ''               | :create
+`keyid`            | String        | Remote repository key ID                     | ''               | :create
+`keyserver`        | String        | Keys server                                  | 'keys.gnupg.net' | :create
+`cookbook`         | String        | Cookbook name where you've store the keyfile | ''               | :create
+`keyfile`          | String        | Key file name                                | ''               | :create
+`filter`           | String        | Mirror filter                                | ''               | :creates
+`filter_with_deps` | [true, false] | Include dependencies of filtered packages    | false            | :creates
 
 #### Examples
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -29,6 +29,10 @@ module Aptly
         node['platform_version'].to_f < 18.04 ? 'gpg' : 'gpg1'
       end
     end
+
+    def filter_with_deps(a)
+      a == true ? '-filter-with-deps' : ''
+    end
   end
 end
 

--- a/resources/mirror.rb
+++ b/resources/mirror.rb
@@ -16,15 +16,16 @@
 # limitations under the License.
 #
 
-property :mirror_name,  String, name_property: true
-property :component,    String, default: ''
-property :distribution, String, default: ''
-property :uri,          String, default: ''
-property :keyid,        String, default: ''
-property :keyserver,    String, default: 'keys.gnupg.net'
-property :cookbook,     String, default: ''
-property :keyfile,      String, default: ''
-property :filter,       String, default: ''
+property :mirror_name,      String, name_property: true
+property :component,        String, default: ''
+property :distribution,     String, default: ''
+property :uri,              String, default: ''
+property :keyid,            String, default: ''
+property :keyserver,        String, default: 'keys.gnupg.net'
+property :cookbook,         String, default: ''
+property :keyfile,          String, default: ''
+property :filter,           String, default: ''
+property :filter_with_deps, [true, false], default: false
 
 action :create do
   if !new_resource.cookbook.empty? && !new_resource.keyfile.empty?
@@ -43,7 +44,7 @@ action :create do
   end
 
   execute "Creating mirror - #{new_resource.mirror_name}" do
-    command "aptly mirror create -filter '#{new_resource.filter}' #{new_resource.mirror_name} #{new_resource.uri} #{new_resource.distribution} #{new_resource.component}"
+    command "aptly mirror create -filter '#{new_resource.filter}' #{filter_with_deps(new_resource.filter_with_deps)} #{new_resource.mirror_name} #{new_resource.uri} #{new_resource.distribution} #{new_resource.component}"
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env


### PR DESCRIPTION
### Description

Add ability to use Aptly's -filter-with-deps feature when creating mirrors.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
