### PR TITLE
Fix broken `not_if in mirror.rb.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the aptly cookbook.
 
 ## Unreleased
 
+- Fix broken `not_if` for in aptly_mirror resource.
 - Migrate to circleci for testing
 
 ## v1.0.0 (24-10-2018)

--- a/resources/mirror.rb
+++ b/resources/mirror.rb
@@ -79,7 +79,7 @@ action_class do
       group node['aptly']['group']
       environment aptly_env
       retries 2
-      not_if %(#{gpg_command} --list-keys #{keyid})
+      not_if %(#{gpg_command} --keyring trustedkeys.gpg --list-keys #{keyid})
     end
   end
 

--- a/spec/unit/resources/mirror_spec.rb
+++ b/spec/unit/resources/mirror_spec.rb
@@ -50,8 +50,8 @@ platforms.each do |platform, version|
 
     context 'Create action test' do
       before do
-        stub_command('gpg --list-keys 437D05B5').and_return(false)
-        stub_command('gpg1 --list-keys 437D05B5').and_return(false)
+        stub_command('gpg --keyring trustedkeys.gpg --list-keys 437D05B5').and_return(false)
+        stub_command('gpg1 --keyring trustedkeys.gpg --list-keys 437D05B5').and_return(false)
         stub_command('aptly mirror -raw list | grep ^ubuntu-precise-main$').and_return(false)
       end
       it 'Run the custom resources' do
@@ -66,8 +66,8 @@ platforms.each do |platform, version|
 
     context 'Update and Drop action test' do
       before do
-        stub_command('gpg --list-keys 437D05B5').and_return(false)
-        stub_command('gpg1 --list-keys 437D05B5').and_return(false)
+        stub_command('gpg --keyring trustedkeys.gpg --list-keys 437D05B5').and_return(false)
+        stub_command('gpg1 --keyring trustedkeys.gpg --list-keys 437D05B5').and_return(false)
         stub_command('aptly mirror -raw list | grep ^ubuntu-precise-main$').and_return(true)
       end
       it 'Run the custom resources' do


### PR DESCRIPTION
### Description

`Installing external repository key` resource would always run since the `not_if` is not running gpg against correct keyring.

### Issues Resolved

No issues created, did a PR instead.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
