### PR TITLE
Fix a typo in the URL in metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,5 +10,5 @@ chef_version '>= 12.14' if respond_to?(:chef_version)
 supports 'ubuntu'
 supports 'debian'
 
-issues_url 'https://github.com/sous-chef/aptly/issues'
-source_url 'https://github.com/sous-chef/aptly'
+issues_url 'https://github.com/sous-chefs/aptly/issues'
+source_url 'https://github.com/sous-chefs/aptly'


### PR DESCRIPTION
### Description

The `issues_url` and `source_url` links were wrong, leading to broken links on Supermarket.

### Issues Resolved

N/A

### Check List

- [N/A] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable
