### PR TITLE
add timeout option for mirror & publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the aptly cookbook.
 
 ## Unreleased
 
+- Add timeout argument for some time consuming resources.
 - Fix broken `not_if` for in aptly_mirror resource.
 - Migrate to circleci for testing
 - add support for aptly mirror `-filter-with-deps` argument.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Name               | Types         | Description                                
 `keyfile`          | String        | Key file name                                | ''               | :create
 `filter`           | String        | Mirror filter                                | ''               | :creates
 `filter_with_deps` | [true, false] | Include dependencies of filtered packages    | false            | :creates
+`timeout`          | Integer       | Timeout in seconds                           | 3600             | :update
 
 #### Examples
 
@@ -258,15 +259,16 @@ Publish, remove or update a repo or a snapshot
 
 #### Properties
 
-Name            | Types  | Description                                     | Default          | Used with...
---------------- | ------ | ----------------------------------------------- | ---------------- | ----------------
-`publish_name`  | String | Publication name                                | <resource_name>  | all
-`type`          | String | Publish type (snapshot or repo)                 | ''               | :create
-`component`     | String | Component name to publish                       | []               | :create
-`distribution`  | String | Distribution name to publish                    | ''               | :create
-`architectures` | String | Only mentioned architectures would be published | ['amd64']        | :create
-`endpoint`      | String | An optional endpoint reference                  | ''               | :create, :update
-`prefix`        | String | An optional prefix for publishing               | ''               | :create, :update
+Name            | Types   | Description                                     | Default          | Used with...
+--------------- | ------- | ----------------------------------------------- | ---------------- | ----------------
+`publish_name`  | String  | Publication name                                | <resource_name>  | all
+`type`          | String  | Publish type (snapshot or repo)                 | ''               | :create
+`component`     | String  | Component name to publish                       | []               | :create
+`distribution`  | String  | Distribution name to publish                    | ''               | :create
+`architectures` | String  | Only mentioned architectures would be published | ['amd64']        | :create
+`endpoint`      | String  | An optional endpoint reference                  | ''               | :create, :update
+`prefix`        | String  | An optional prefix for publishing               | ''               | :create, :update
+`timeout`       | Integer | Timeout in seconds                              | 3600             | all
 
 
 #### Examples

--- a/resources/mirror.rb
+++ b/resources/mirror.rb
@@ -26,6 +26,7 @@ property :cookbook,         String, default: ''
 property :keyfile,          String, default: ''
 property :filter,           String, default: ''
 property :filter_with_deps, [true, false], default: false
+property :timeout,          Integer, default: 3600
 
 action :create do
   if !new_resource.cookbook.empty? && !new_resource.keyfile.empty?
@@ -58,6 +59,7 @@ action :update do
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env
+    timeout new_resource.timeout
     only_if %(aptly mirror -raw list | grep ^#{new_resource.mirror_name}$)
   end
 end

--- a/resources/publish.rb
+++ b/resources/publish.rb
@@ -23,6 +23,7 @@ property :component,     Array, default: []
 property :architectures, Array, default: ['amd64']
 property :prefix,        String, default: ''
 property :distribution,  String, default: ''
+property :timeout,       Integer, default: 3600
 
 action :create do
   components = new_resource.component.join(',')
@@ -35,6 +36,7 @@ action :create do
     group node['aptly']['group']
     environment aptly_env
     sensitive true
+    timeout new_resource.timeout
     not_if %(aptly publish list | grep #{new_resource.publish_name})
   end
 end
@@ -46,6 +48,7 @@ action :update do
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env
+    timeout new_resource.timeout
   end
 end
 
@@ -58,6 +61,7 @@ action :drop do
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env
+    timeout new_resource.timeout
     only_if %(aptly publish list | grep #{new_resource.publish_name})
   end
 end


### PR DESCRIPTION
### Description
Add timeout for some actions in mirror and publish resources that can be expected to run for longer than the default of 1 hour.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
