### PR TITLE
Fix "cant modify frozen String" error caused by aptly_snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ This file is used to list changes made in each version of the aptly cookbook.
 
 ## Unreleased
 
-- Add timeout argument for some time consuming resources.
-- Fix broken `not_if` for in aptly_mirror resource.
+- Fix "can't modify frozen String" error caused by aptly_snapshot
+- Add timeout argument for some time consuming resources
+- Fix broken `not_if` for in aptly_mirror resource
 - Migrate to circleci for testing
-- add support for aptly mirror `-filter-with-deps` argument.
+- add support for aptly mirror `-filter-with-deps` argument
 
 ## v1.0.0 (24-10-2018)
 

--- a/resources/snapshot.rb
+++ b/resources/snapshot.rb
@@ -60,8 +60,8 @@ end
 
 action :pull do
   opts = ''
-  opts << ' -no-deps' if new_resource.no_deps
-  opts << ' -no-remove' if new_resource.no_remove
+  opts += ' -no-deps' if new_resource.no_deps
+  opts += ' -no-remove' if new_resource.no_remove
 
   execute "Pull to - #{new_resource.snapshot_name}" do
     command "aptly snapshot pull#{opts} #{new_resource.snapshot_name} #{new_resource.source} #{new_resource.destination} #{new_resource.package_query}"
@@ -74,8 +74,8 @@ end
 
 action :merge do
   opts = ''
-  opts << ' -latest' if new_resource.latest
-  opts << ' -no-remove' if new_resource.no_remove
+  opts += ' -latest' if new_resource.latest
+  opts += ' -no-remove' if new_resource.no_remove
   flatten_sources = new_resource.merge_sources.join(' ')
 
   execute "Merge Snapshots #{flatten_sources} TO #{new_resource.snapshot_name}" do


### PR DESCRIPTION
### Description
frozen_string_literal is enabled and will be default in Ruby 3.
This fixes fix "cant modify frozen String" error caused by aptly_snapshot.


### Issues Resolved
```

    RuntimeError
    ------------
    can't modify frozen String

    Cookbook Trace:
    ---------------
    /var/cache/chef/cookbooks/aptly/resources/snapshot.rb:78:in `block in class_from_file'

    Resource Declaration:
    ---------------------
    # In /var/cache/chef/cookbooks/dp_aptly_wrapper/recipes/dell_omsa.rb

    112: aptly_snapshot 'osma-trusty' do
    113:   merge_sources %w(omsa8-trusty omsa902-trusty)
    114:   no_remove true
    115:   action :merge
    116: end
    117:
```

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
