### PR TITLE
Add helper function and properties for -with-udebs and -architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the aptly cookbook.
 - Fix broken `not_if` for in aptly_mirror resource
 - Migrate to circleci for testing
 - add support for aptly mirror `-filter-with-deps` argument
+- add support for aptly mirror `-with-udebs` and `-architectures` arguments
 
 ## v1.0.0 (24-10-2018)
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,11 @@ Name               | Types         | Description                                
 `keyfile`          | String        | Key file name                                | ''               | :create
 `filter`           | String        | Mirror filter                                | ''               | :creates
 `filter_with_deps` | [true, false] | Include dependencies of filtered packages    | false            | :creates
+`architectures`    | String        | Comma-separated list of archs                | ''               | :creates
+`with_udebs`       | [true, false] | Whether or not to download .udeb packages    | false            | :creates
 `timeout`          | Integer       | Timeout in seconds                           | 3600             | :update
+
+Note: The "architectures" property will use the global configuration (settable via node['aptly']['architectures']) if you do not provide it for a particular repository here. If you do not provide either of them, it will default to all available architectures for that particular mirror.
 
 #### Examples
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -33,6 +33,14 @@ module Aptly
     def filter_with_deps(a)
       a == true ? '-filter-with-deps' : ''
     end
+
+    def with_udebs(u)
+      u == true ? '-with-udebs' : ''
+    end
+
+    def architectures(a)
+      a.empty? ? '' : "-architectures #{a}"
+    end
   end
 end
 

--- a/resources/mirror.rb
+++ b/resources/mirror.rb
@@ -26,6 +26,8 @@ property :cookbook,         String, default: ''
 property :keyfile,          String, default: ''
 property :filter,           String, default: ''
 property :filter_with_deps, [true, false], default: false
+property :architectures,    String, default: ''
+property :with_udebs,       [true, false], default: false
 property :timeout,          Integer, default: 3600
 
 action :create do
@@ -45,7 +47,7 @@ action :create do
   end
 
   execute "Creating mirror - #{new_resource.mirror_name}" do
-    command "aptly mirror create -filter '#{new_resource.filter}' #{filter_with_deps(new_resource.filter_with_deps)} #{new_resource.mirror_name} #{new_resource.uri} #{new_resource.distribution} #{new_resource.component}"
+    command "aptly mirror create #{with_udebs(new_resource.with_udebs)} #{architectures(new_resource.architectures)} -filter '#{new_resource.filter}' #{filter_with_deps(new_resource.filter_with_deps)} #{new_resource.mirror_name} #{new_resource.uri} #{new_resource.distribution} #{new_resource.component}"
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env


### PR DESCRIPTION
### Description

Add -with-udebs and -architectures to aptly mirror create.

### Issues Resolved

#49 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
