### PR TITLE
v1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ This file is used to list changes made in each version of the aptly cookbook.
 
 ## Unreleased
 
-- Fix "can't modify frozen String" error caused by aptly_snapshot
+## v1.1.0 (08-03-2019)
+
 - Add timeout argument for some time consuming resources
+- Add support for aptly mirror `-filter-with-deps` argument
+- Add support for aptly mirror `-with-udebs` and `-architectures` arguments
+- Fix "can't modify frozen String" error caused by aptly_snapshot
 - Fix broken `not_if` for in aptly_mirror resource
 - Migrate to circleci for testing
-- add support for aptly mirror `-filter-with-deps` argument
-- add support for aptly mirror `-with-udebs` and `-architectures` arguments
 
 ## v1.0.0 (24-10-2018)
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,11 +1,11 @@
-name 'aptly'
-maintainer 'Heavy Water Operations, LLC'
-maintainer_email 'aaronb@heavywater.io'
-license 'Apache-2.0'
-description 'Installs/Configures aptly'
+name             'aptly'
+maintainer       'Sous Chefs'
+maintainer_email 'help@sous-chefs.org'
+license          'Apache-2.0'
+description      'Installs/Configures aptly'
 long_description 'Installs/Configures aptly'
-version '1.0.0'
-chef_version '>= 12.14' if respond_to?(:chef_version)
+version          '1.1.0'
+chef_version     '>= 12.14' if respond_to?(:chef_version)
 
 supports 'ubuntu'
 supports 'debian'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'Apache-2.0'
 description      'Installs/Configures aptly'
 long_description 'Installs/Configures aptly'
 version          '1.1.0'
-chef_version     '>= 12.14' if respond_to?(:chef_version)
+chef_version     '>= 13.0' if respond_to?(:chef_version)
 
 supports 'ubuntu'
 supports 'debian'


### PR DESCRIPTION
### Description

Release v1.1.0

### Changelog

- Add timeout argument for some time consuming resources
- Add support for aptly mirror `-filter-with-deps` argument
- Add support for aptly mirror `-with-udebs` and `-architectures` arguments
- Fix "can't modify frozen String" error caused by aptly_snapshot
- Fix broken `not_if` for in aptly_mirror resource
- Migrate to circleci for testing

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
