### PR TITLE
Make the architectures property consistent between mirror and publish.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file is used to list changes made in each version of the aptly cookbook.
 
 ## Unreleased
+- Change `architectures` argument in both mirror and publish resource for consistency.
 
 ## v1.1.0 (08-03-2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file is used to list changes made in each version of the aptly cookbook.
 
 ## Unreleased
-- Change `architectures` argument in both mirror and publish resource for consistency.
+- Change `architectures` argument in both the mirror and publish resources for consistency.
 
 ## v1.1.0 (08-03-2019)
 

--- a/README.md
+++ b/README.md
@@ -153,13 +153,13 @@ Name               | Types         | Description                                
 `keyserver`        | String        | Keys server                                  | 'keys.gnupg.net' | :create
 `cookbook`         | String        | Cookbook name where you've store the keyfile | ''               | :create
 `keyfile`          | String        | Key file name                                | ''               | :create
-`filter`           | String        | Mirror filter                                | ''               | :creates
-`filter_with_deps` | [true, false] | Include dependencies of filtered packages    | false            | :creates
-`architectures`    | String        | Comma-separated list of archs                | ''               | :creates
-`with_udebs`       | [true, false] | Whether or not to download .udeb packages    | false            | :creates
+`filter`           | String        | Mirror filter                                | ''               | :create
+`filter_with_deps` | [true, false] | Include dependencies of filtered packages    | false            | :create
+`architectures`    | Array         | List of architectures.                       | []               | :create
+`with_udebs`       | [true, false] | Whether or not to download .udeb packages    | false            | :create
 `timeout`          | Integer       | Timeout in seconds                           | 3600             | :update
 
-Note: The "architectures" property will use the global configuration (settable via node['aptly']['architectures']) if you do not provide it for a particular repository here. If you do not provide either of them, it will default to all available architectures for that particular mirror.
+Note: The "architectures" property will use the global configuration (settable via node['aptly']['architectures']) if you do not provide it for a particular repository here. If you do not provide either of them, it will default to all available architectures for that particular mirror. Note also that you need to `publish` with the architectures as well!
 
 #### Examples
 
@@ -269,11 +269,12 @@ Name            | Types   | Description                                     | De
 `type`          | String  | Publish type (snapshot or repo)                 | ''               | :create
 `component`     | String  | Component name to publish                       | []               | :create
 `distribution`  | String  | Distribution name to publish                    | ''               | :create
-`architectures` | String  | Only mentioned architectures would be published | ['amd64']        | :create
+`architectures` | Array   | Only mentioned architectures would be published | []               | :create
 `endpoint`      | String  | An optional endpoint reference                  | ''               | :create, :update
 `prefix`        | String  | An optional prefix for publishing               | ''               | :create, :update
 `timeout`       | Integer | Timeout in seconds                              | 3600             | all
 
+Note: The "architectures" property will use the global configuration (settable via node['aptly']['architectures']) if you do not provide it for a particular repository here.
 
 #### Examples
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -38,8 +38,8 @@ module Aptly
       u == true ? '-with-udebs' : ''
     end
 
-    def architectures(a)
-      a.empty? ? '' : "-architectures #{a}"
+    def architectures(arr)
+      arr.empty? ? '' : "-architectures #{arr.join(',')}"
     end
   end
 end

--- a/resources/mirror.rb
+++ b/resources/mirror.rb
@@ -26,7 +26,7 @@ property :cookbook,         String, default: ''
 property :keyfile,          String, default: ''
 property :filter,           String, default: ''
 property :filter_with_deps, [true, false], default: false
-property :architectures,    String, default: ''
+property :architectures,    Array, default: []
 property :with_udebs,       [true, false], default: false
 property :timeout,          Integer, default: 3600
 

--- a/resources/publish.rb
+++ b/resources/publish.rb
@@ -20,18 +20,17 @@ property :publish_name,  String, name_property: true
 property :type,          String, default: ''
 property :endpoint,      String, default: ''
 property :component,     Array, default: []
-property :architectures, Array, default: ['amd64']
+property :architectures, Array, default: []
 property :prefix,        String, default: ''
 property :distribution,  String, default: ''
 property :timeout,       Integer, default: 3600
 
 action :create do
   components = new_resource.component.join(',')
-  architectures = new_resource.architectures.join(',')
   endpoint = new_resource.endpoint.empty? ? '' : "#{new_resource.endpoint}:"
 
   execute "Publish #{new_resource.type} - #{new_resource.publish_name}" do
-    command "aptly publish #{new_resource.type} -batch -passphrase='#{node['aptly']['gpg']['passphrase']}' -component='#{components}' -architectures='#{architectures}' -distribution='#{new_resource.distribution}' -- #{new_resource.publish_name} #{endpoint}#{new_resource.prefix}"
+    command "aptly publish #{new_resource.type} -batch -passphrase='#{node['aptly']['gpg']['passphrase']}' -component='#{components}' #{architectures(new_resource.architectures)} -distribution='#{new_resource.distribution}' -- #{new_resource.publish_name} #{endpoint}#{new_resource.prefix}"
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env


### PR DESCRIPTION
Signed-off-by: Joshua Justice <jjustice6@bloomberg.net>

### Description

In my previous PR, I was unaware that `aptly publish` also took an architectures property, and as a result I didn't make the addition of architectures to `aptly mirror` use an array.

In addition, I noticed that `aptly publish` without an architectures argument defaults to the global default; so there's no need for forcing the `amd64` default here. I talked it over with @Raboo and we agreed this is the correct choice in the long run, but note that this _is_ a breaking change.

### Issues Resolved

N/A

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
