### PR TITLE
Add a 'with_installer' parameter to aptly mirror.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the aptly cookbook.
 
 ## Unreleased
 - Change `architectures` argument in both the mirror and publish resources for consistency.
+- Add a `with_installer` parameter to the mirror resource.
 
 ## v1.1.0 (08-03-2019)
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Name               | Types         | Description                                
 `filter`           | String        | Mirror filter                                | ''               | :create
 `filter_with_deps` | [true, false] | Include dependencies of filtered packages    | false            | :create
 `architectures`    | Array         | List of architectures.                       | []               | :create
+`with_installer`   | [true, false] | Whether to download installer files          | false            | :create
 `with_udebs`       | [true, false] | Whether or not to download .udeb packages    | false            | :create
 `timeout`          | Integer       | Timeout in seconds                           | 3600             | :update
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -34,6 +34,10 @@ module Aptly
       a == true ? '-filter-with-deps' : ''
     end
 
+    def with_installer(i)
+      i == true ? '-with-installer' : ''
+    end
+
     def with_udebs(u)
       u == true ? '-with-udebs' : ''
     end

--- a/resources/mirror.rb
+++ b/resources/mirror.rb
@@ -27,6 +27,7 @@ property :keyfile,          String, default: ''
 property :filter,           String, default: ''
 property :filter_with_deps, [true, false], default: false
 property :architectures,    Array, default: []
+property :with_installer,   [true, false], default: false
 property :with_udebs,       [true, false], default: false
 property :timeout,          Integer, default: 3600
 
@@ -47,7 +48,7 @@ action :create do
   end
 
   execute "Creating mirror - #{new_resource.mirror_name}" do
-    command "aptly mirror create #{with_udebs(new_resource.with_udebs)} #{architectures(new_resource.architectures)} -filter '#{new_resource.filter}' #{filter_with_deps(new_resource.filter_with_deps)} #{new_resource.mirror_name} #{new_resource.uri} #{new_resource.distribution} #{new_resource.component}"
+    command "aptly mirror create #{with_installer(new_resource.with_installer)} #{with_udebs(new_resource.with_udebs)} #{architectures(new_resource.architectures)} -filter '#{new_resource.filter}' #{filter_with_deps(new_resource.filter_with_deps)} #{new_resource.mirror_name} #{new_resource.uri} #{new_resource.distribution} #{new_resource.component}"
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env


### PR DESCRIPTION
### Description

`aptly mirror create` supports a `-with-installer` parameter. This allows the cookbook to replicate that functionality rather than requiring manual `aptly mirror edit` after-the-fact.

https://www.aptly.info/doc/aptly/mirror/create/

### Issues Resolved

Ability to download installer files is provided in Aptly. We should provide that functionality via the cookbook.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
