### PR TITLE
Get getent passwd <user> to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `true` and `false` in resources
 - Migrate to Github Actions for testing
 
+## 2.0.2 2020-02-14
+
+### Added
+
+### Fixed
+
+- Changed usage of getent <user> passwd to getent passwd <user> 
+
+### Deprecated
+
+### Removed
+
 ## 2.0.1 2019-10-19
 
 ### Added

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,7 +40,7 @@ directory node['aptly']['rootDir'] do
   group node['aptly']['group']
   mode '0755'
   recursive true
-  only_if "getent #{node['aptly']['user']} passwd"
+  only_if "getent passwd #{node['aptly']['user']}"
 end
 
 group node['aptly']['group'] do


### PR DESCRIPTION
Changed from getent <user> passwd to getent passwd <user>. Tested in Debian 9.13.

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
