### PR TITLE
aptly_publish: accept alternative passphrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Allow specifying GPG passphrase explicitly in the publish resource
+
 ## 2.3.2 (2020-11-16)
 
 - resolved cookstyle error: test/fixtures/cookbooks/aptly_test/recipes/default.rb:95:3 convention: `Style/CommentAnnotation`

--- a/resources/publish.rb
+++ b/resources/publish.rb
@@ -24,13 +24,14 @@ property :architectures, Array, default: []
 property :prefix,        String, default: ''
 property :distribution,  String, default: ''
 property :timeout,       Integer, default: 3600
+property :gpg_passphrase, String, default: lazy { node['aptly']['gpg']['passphrase'] }
 
 action :create do
   components = new_resource.component.join(',')
   endpoint = new_resource.endpoint.empty? ? '' : "#{new_resource.endpoint}:"
 
   execute "Publish #{new_resource.type} - #{new_resource.publish_name}" do
-    command "aptly publish #{new_resource.type} -batch -passphrase='#{node['aptly']['gpg']['passphrase']}' -component='#{components}' #{architectures(new_resource.architectures)} -distribution='#{new_resource.distribution}' -- #{new_resource.publish_name} #{endpoint}#{new_resource.prefix}"
+    command "aptly publish #{new_resource.type} -batch -passphrase='#{new_resource.gpg_passphrase}' -component='#{components}' #{architectures(new_resource.architectures)} -distribution='#{new_resource.distribution}' -- #{new_resource.publish_name} #{endpoint}#{new_resource.prefix}"
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env
@@ -42,8 +43,9 @@ end
 
 action :update do
   endpoint = new_resource.endpoint.empty? ? '' : "#{new_resource.endpoint}:"
+
   execute "Updating distribution - #{new_resource.prefix} #{new_resource.publish_name}" do
-    command "aptly publish update -batch -passphrase='#{node['aptly']['gpg']['passphrase']}' #{new_resource.publish_name} #{endpoint}#{new_resource.prefix}"
+    command "aptly publish update -batch -passphrase='#{new_resource.gpg_passphrase}' #{new_resource.publish_name} #{endpoint}#{new_resource.prefix}"
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env


### PR DESCRIPTION
If we did something like replace GPG key at runtime with a new one, it's
difficult (at least I don't know of a way) to tell the the aptly recipe
about the password.

That is, `node.override` can only be used at compile time. If we get our
GPG password at converge time (say, we load it from AWS SSM via aws
cookbook), we can not set the attribute with the right value.

As a work-around, we can allow specifying passphrase directly to the
resource, which we are allowed to populate with runtime-derived values.

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
