### PR TITLE
Add :switch action to aptly_publish resource

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
         os:
           - "debian-10"
           - "debian-9"
-          - "ubuntu-1604"
           - "ubuntu-1804"
           - "ubuntu-2004"
         suite:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           - "debian-9"
           - "ubuntu-1604"
           - "ubuntu-1804"
+          - "ubuntu-2004"
         suite:
           - "default"
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Add `switch` action to `aptly_publish` resource
+
 ## 3.0.0 - *2021-09-02*
 
 - Set unified_mode to true for Chef 17 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Add `switch` action to `aptly_publish` resource
+- Add Ubuntu 20.04 to testing matrix; remove Ubuntu 16.04
 
 ## 3.0.0 - *2021-09-02*
 

--- a/README.md
+++ b/README.md
@@ -87,9 +87,7 @@ After modifications, please run the following commands to check if you break som
 - chef exec rspec
 - kitchen test default-ubuntu-1804
 
-NOTE: Available distro tests: `default-debian-8`, `default-debian-9`, `default-ubuntu-1604`, `default-ubuntu-1804` and `default-ubuntu-2004`
-
-NOTE2: if you want to use Policyfile, rename `Policyfile.rb.dist` to `Policyfile.rb` in root and test directories, then execute `chef update` in each folder. Look inside `.kitchen.yml` and `spec/spec_helper.rb` too.
+NOTE: if you want to use Policyfile, rename `Policyfile.rb.dist` to `Policyfile.rb` in root and test directories, then execute `chef update` in each folder. Look inside `.kitchen.yml` and `spec/spec_helper.rb` too.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ After modifications, please run the following commands to check if you break som
 - chef exec rspec
 - kitchen test default-ubuntu-1804
 
-NOTE: Available distro tests: `default-debian-8`, `default-debian-9`, `default-ubuntu-1604` and `default-ubuntu-1804`
+NOTE: Available distro tests: `default-debian-8`, `default-debian-9`, `default-ubuntu-1604`, `default-ubuntu-1804` and `default-ubuntu-2004`
 
 NOTE2: if you want to use Policyfile, rename `Policyfile.rb.dist` to `Policyfile.rb` in root and test directories, then execute `chef update` in each folder. Look inside `.kitchen.yml` and `spec/spec_helper.rb` too.
 

--- a/documentation/resources/aptly_publish.md
+++ b/documentation/resources/aptly_publish.md
@@ -6,20 +6,21 @@ Publish, remove or update a repo or a snapshot
 
 - `create` - (default) Publish a repo or a snapshot
 - `drop` - Drop a publication
+- `switch` - Switch published snapshot to a new snapshot
 - `update` - Update publication
 
 ## Properties
 
-| Name            | Types   | Description                                     | Default         | Used with...     |
-| --------------- | ------- | ----------------------------------------------- | --------------- | ---------------- |
-| `publish_name`  | String  | Publication name                                | <resource_name> | all              |
-| `type`          | String  | Publish type (snapshot or repo)                 | ''              | :create          |
-| `component`     | String  | Component name to publish                       | []              | :create          |
-| `distribution`  | String  | Distribution name to publish                    | ''              | :create          |
-| `architectures` | Array   | Only mentioned architectures would be published | []              | :create          |
-| `endpoint`      | String  | An optional endpoint reference                  | ''              | :create, :update |
-| `prefix`        | String  | An optional prefix for publishing               | ''              | :create, :update |
-| `timeout`       | Integer | Timeout in seconds                              | 3600            | all              |
+| Name            | Types   | Description                                     | Default         | Used with...              |
+| --------------- | ------- | ----------------------------------------------- | --------------- | ------------------------- |
+| `publish_name`  | String  | Publication name                                | <resource_name> | all                       |
+| `type`          | String  | Publish type (snapshot or repo)                 | ''              | :create                   |
+| `component`     | String  | Component name to publish                       | []              | :create, :switch          |
+| `distribution`  | String  | Distribution name to publish                    | ''              | :create, :switch          |
+| `architectures` | Array   | Only mentioned architectures would be published | []              | :create                   |
+| `endpoint`      | String  | An optional endpoint reference                  | ''              | :create, :switch, :update |
+| `prefix`        | String  | An optional prefix for publishing               | ''              | :create, :switch, :update |
+| `timeout`       | Integer | Timeout in seconds                              | 3600            | all                       |
 
 Note: The "architectures" property will use the global configuration (settable via node['aptly']['architectures']) if you do not provide it for a particular repository here.
 
@@ -53,6 +54,21 @@ end
 aptly_publish 'my_snapshot' do
   prefix 'snap'
   action :drop
+end
+```
+
+```ruby
+aptly_publish 'my_snapshot' do
+  type 'snapshot'
+  prefix 'snap'
+  action :create
+end
+
+aptly_publish 'my_new_snapshot' do
+  type 'snapshot'
+  prefix 'snap'
+  distribution 'bionic' # distribution must be provided with :switch
+  action :switch
 end
 ```
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -25,6 +25,10 @@ platforms:
     driver:
       image: dokken/ubuntu-18.04
       pid_one_command: /bin/systemd
+  - name: ubuntu-20.04
+    driver:
+      image: dokken/ubuntu-20.04
+      pid_one_command: /bin/systemd
   - name: debian-9
     driver:
       image: dokken/debian-9

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,7 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_zero
+  product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   install_strategy: once
   deprecations_as_errors: true
@@ -15,6 +15,7 @@ verifier:
 platforms:
   - name: ubuntu-16.04
   - name: ubuntu-18.04
+  - name: ubuntu-20.04
   - name: debian-10
   - name: debian-9
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -13,7 +13,6 @@ verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-16.04
   - name: ubuntu-18.04
   - name: ubuntu-20.04
   - name: debian-10

--- a/resources/publish.rb
+++ b/resources/publish.rb
@@ -40,6 +40,19 @@ action :create do
   end
 end
 
+action :switch do
+  endpoint = new_resource.endpoint.empty? ? '' : "#{new_resource.endpoint}:"
+  component = new_resource.component.empty? ? '' : "-component=#{new_resource.component.join(',')}"
+  execute "Switching distribution - #{new_resource.prefix}/#{new_resource.distribution} #{new_resource.publish_name}" do
+    command "aptly publish switch -batch -passphrase='#{node['aptly']['gpg']['passphrase']}' #{component} #{new_resource.distribution} #{endpoint}#{new_resource.prefix} #{new_resource.publish_name}"
+    user node['aptly']['user']
+    group node['aptly']['group']
+    environment aptly_env
+    sensitive true
+    timeout new_resource.timeout
+  end
+end
+
 action :update do
   endpoint = new_resource.endpoint.empty? ? '' : "#{new_resource.endpoint}:"
   execute "Updating distribution - #{new_resource.prefix} #{new_resource.publish_name}" do

--- a/test/fixtures/cookbooks/aptly_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/aptly_test/recipes/default.rb
@@ -113,6 +113,11 @@ aptly_snapshot 'my_mirror_snapshot' do
   type 'mirror'
 end
 
+aptly_snapshot 'my_switch_snapshot' do
+  from 'nginx-bionic-main'
+  type 'mirror'
+end
+
 aptly_snapshot 'my_snapshot' do
   action :verify
 end
@@ -146,6 +151,20 @@ end
 aptly_publish 'bionic' do
   prefix 'mirror'
   action :drop
+end
+
+aptly_publish 'my_snapshot_for_switch' do
+  publish_name 'my_mirror_snapshot'
+  type 'snapshot'
+  prefix 'switch'
+  not_if %(aptly publish list -raw | egrep '^switch bionic$')
+end
+
+aptly_publish 'my_switch_snapshot' do
+  type 'snapshot'
+  distribution 'bionic'
+  prefix 'switch'
+  action :switch
 end
 
 aptly_db 'Cleanup'

--- a/test/integration/default/resources_test.rb
+++ b/test/integration/default/resources_test.rb
@@ -70,6 +70,8 @@ control 'Resources Tests' do
 
   describe command('aptly publish list') do
     its('stdout') { should match %r{snap/bionic} }
+    its('stdout') { should match %r{switch/bionic.*my_switch_snapshot} }
+    its('stdout') { should_not match %r{switch/bionic.*my_mirror_snapshot} }
     its('exit_status') { should eq 0 }
   end
 


### PR DESCRIPTION
# Description

- Add `switch` action to `aptly_publish` resource
- Add Ubuntu 20.04 to test platforms

NOTE: Cookstyle and some integration tests are failing because #111 has not been merged yet and `deprecations_as_errors: true` is set.

## Issues Resolved

#112 

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
