### PR TITLE
feat: support keyserver URIs in mirrors

### DIFF
--- a/documentation/resources/aptly_mirror.md
+++ b/documentation/resources/aptly_mirror.md
@@ -17,7 +17,7 @@ Manage an external Aptly mirror.
 | `distribution` | String | `''` | Distribution passed to `aptly mirror create` |
 | `uri` | String | `''` | Upstream mirror URL |
 | `keyid` | String | `''` | Remote repository signing key ID |
-| `keyserver` | String | `'keys.gnupg.net'` | Keyserver used with `keyid` |
+| `keyserver` | String | `'keys.gnupg.net'` | Keyserver used with `keyid`; accepts either a bare hostname or a full URI such as `hkps://keys.openpgp.org` |
 | `cookbook` | String | `''` | Cookbook containing `keyfile` |
 | `keyfile` | String | `''` | Local key file imported into Aptly's trusted keyring |
 | `filter` | String | `''` | Aptly package filter |
@@ -36,7 +36,7 @@ Manage an external Aptly mirror.
 | `root_dir` | String | `'/opt/aptly'` | Shared common property |
 | `tmp_dir` | String | `'/tmp'` | Shared common property |
 
-## Example
+## Examples
 
 ```ruby
 aptly_mirror 'nginx-bionic' do
@@ -46,5 +46,15 @@ aptly_mirror 'nginx-bionic' do
   keyid '7BD9BF62'
   keyserver 'keyserver.ubuntu.com'
   filter 'nginx (>= 1.16.1)'
+end
+```
+
+```ruby
+aptly_mirror 'debian-bookworm' do
+  distribution 'bookworm'
+  component 'main'
+  uri 'https://deb.debian.org/debian/'
+  keyid 'B7C5D7D6350947F8'
+  keyserver 'hkps://keys.openpgp.org'
 end
 ```

--- a/resources/mirror.rb
+++ b/resources/mirror.rb
@@ -136,12 +136,16 @@ action_class do
     end
 
     execute "Import GPG key #{keyid}" do
-      command "gpg --no-default-keyring --keyring #{new_resource.root_dir}/.gnupg/trustedkeys.gpg --keyserver hkp://#{keyserver} --recv-keys #{keyid}"
+      command "gpg --no-default-keyring --keyring #{new_resource.root_dir}/.gnupg/trustedkeys.gpg --keyserver #{keyserver_uri(keyserver)} --recv-keys #{keyid}"
       user new_resource.user
       group new_resource.group
       environment resource_env
       not_if "gpg --no-default-keyring --keyring #{new_resource.root_dir}/.gnupg/trustedkeys.gpg --list-keys #{keyid}"
     end
+  end
+
+  def keyserver_uri(keyserver)
+    keyserver.match?(%r{^[a-z][a-z0-9+\-.]*://}i) ? keyserver : "hkp://#{keyserver}"
   end
 
   def install_local_key(keyfile, cb)

--- a/spec/fixtures/cookbooks/aptly_spec/recipes/mirror_hkps.rb
+++ b/spec/fixtures/cookbooks/aptly_spec/recipes/mirror_hkps.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook:: aptly_spec
+# Recipe:: mirror_hkps
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+aptly_mirror 'ubuntu-precise-main' do
+  distribution 'precise'
+  component 'main'
+  keyid '437D05B5'
+  keyserver 'hkps://keys.openpgp.org'
+  uri 'http://ubuntu.osuosl.org/ubuntu/'
+  filter 'my_awesome_package'
+  user 'aptly'
+  group 'aptly'
+  root_dir '/opt/aptly'
+  tmp_dir '/tmp'
+  action :create
+end

--- a/spec/unit/resources/mirror_spec.rb
+++ b/spec/unit/resources/mirror_spec.rb
@@ -30,6 +30,9 @@ platforms.each do |platform, version|
       ChefSpec::SoloRunner.new(platform: platform, version: version, step_into: ['aptly_mirror']).converge('aptly_spec::mirror')
       # ChefSpec::SoloRunner.new(platform: platform, version: version, step_into: ['aptly_mirror']).converge('aptly::default')
     end
+    let(:chef_run_hkps) do
+      ChefSpec::SoloRunner.new(platform: platform, version: version, step_into: ['aptly_mirror']).converge('aptly_spec::mirror_hkps')
+    end
 
     stubs_for_provider('aptly_mirror[ubuntu-precise-main]') do |provider|
       allow(provider).to receive_shell_out('aptly mirror -raw list | grep ^ubuntu-precise-main$', { user: 'aptly', timeout: 3600.0, environment: { 'HOME' => '/opt/aptly', 'USER' => 'aptly' } }, stdout: '', stderr: '', exitstatus: 1)
@@ -60,6 +63,12 @@ platforms.each do |platform, version|
         expect(chef_run).to run_execute('Import system platform keyring')
         expect(chef_run).to run_execute('Creating mirror - ubuntu-precise-main')
       end
+
+      it 'Prefixes host-only keyservers with hkp' do
+        expect(chef_run.execute('Import GPG key 437D05B5').command).to eq(
+          'gpg --no-default-keyring --keyring /opt/aptly/.gnupg/trustedkeys.gpg --keyserver hkp://keys.gnupg.net --recv-keys 437D05B5'
+        )
+      end
     end
 
     context 'Update and Drop action test' do
@@ -73,6 +82,18 @@ platforms.each do |platform, version|
       it 'Steps of resource' do
         expect(chef_run).to run_execute('Updating mirror - ubuntu-precise-main')
         expect(chef_run).to run_execute('Droping mirror - ubuntu-precise-main')
+      end
+    end
+
+    context 'Create action test with hkps keyserver' do
+      before do
+        stub_command('gpg --no-default-keyring --keyring /opt/aptly/.gnupg/trustedkeys.gpg --list-keys 437D05B5').and_return(false)
+      end
+
+      it 'Passes a fully qualified keyserver URI through unchanged' do
+        expect(chef_run_hkps.execute('Import GPG key 437D05B5').command).to eq(
+          'gpg --no-default-keyring --keyring /opt/aptly/.gnupg/trustedkeys.gpg --keyserver hkps://keys.openpgp.org --recv-keys 437D05B5'
+        )
       end
     end
   end


### PR DESCRIPTION
## Summary

- support scheme-qualified keyserver URIs in aptly_mirror while preserving host-only values via hkp:// prefixing
- add ChefSpec coverage for both host-only and hkps:// keyserver inputs
- document the existing keyserver property as accepting either a hostname or a full URI

## Testing

- cookstyle
- /opt/chef-workstation/embedded/bin/rspec

Closes #66