### PR TITLE
fix: harden aptly shell commands

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
+require 'shellwords'
+
 module Aptly
   module Helpers
+    def aptly_command(*args)
+      Shellwords.join(args.flatten.compact.reject { |arg| arg.to_s.empty? }.map(&:to_s))
+    end
+
     def aptly_env(resource = self)
       {
         'HOME' => aptly_property(resource, :root_dir),
@@ -11,7 +17,7 @@ module Aptly
     end
 
     def filter(f)
-      f.empty? ? '' : " -filter '#{f}'"
+      f.empty? ? '' : " -filter #{Shellwords.escape(f)}"
     end
 
     def filter_with_deps(f)
@@ -67,17 +73,49 @@ module Aptly
     end
 
     def architectures(arr)
-      arr.empty? ? '' : " -architectures #{arr.join(',')}"
+      arr.empty? ? '' : " -architectures #{Shellwords.escape(arr.join(','))}"
+    end
+
+    def mirror_create_options(res)
+      args = []
+      args << '-with-installer' if res.with_installer
+      args << '-with-udebs' if res.with_udebs
+      args.push('-architectures', res.architectures.join(',')) unless res.architectures.empty?
+      args.push('-filter', res.filter) unless res.filter.empty?
+      args << '-filter-with-deps' if res.filter_with_deps
+      args << '-dep-follow-all-variants' if res.dep_follow_all_variants
+      args << '-dep-follow-recommends' if res.dep_follow_recommends
+      args << '-dep-follow-source' if res.dep_follow_source
+      args << '-dep-follow-suggests' if res.dep_follow_suggests
+      args << '-dep-verbose-resolve' if res.dep_verbose_resolve
+      args << '-ignore-signatures' if res.ignore_signatures
+      args
+    end
+
+    def mirror_update_options(res)
+      args = []
+      args << '-dep-follow-all-variants' if res.dep_follow_all_variants
+      args << '-dep-follow-recommends' if res.dep_follow_recommends
+      args << '-dep-follow-source' if res.dep_follow_source
+      args << '-dep-follow-suggests' if res.dep_follow_suggests
+      args << '-dep-verbose-resolve' if res.dep_verbose_resolve
+      args << '-ignore-checksums' if res.ignore_checksums
+      args << '-ignore-signatures' if res.ignore_signatures
+      args.push('-download-limit', res.download_limit) if res.download_limit > 0
+      args.push('-max-tries', res.max_tries) if res.max_tries > 1
+      args << '-skip-existing-packages' if res.skip_existing_packages
+      args
     end
 
     def mirror_exists?(mirror_name, resource = self)
-      shell_out("aptly mirror -raw list | grep ^#{mirror_name}$",
+      cmd = shell_out(aptly_command('aptly', 'mirror', '-raw', 'list'),
         user: aptly_property(resource, :user),
-        environment: aptly_env(resource)).exitstatus == 0
+        environment: aptly_env(resource))
+      cmd.exitstatus == 0 && cmd.stdout.lines.any? { |line| line.chomp == mirror_name }
     end
 
     def mirror_show(mirror_name, resource = self)
-      shell_out("aptly mirror show #{mirror_name}",
+      shell_out(aptly_command('aptly', 'mirror', 'show', mirror_name),
         user: aptly_property(resource, :user),
         environment: aptly_env(resource))
     end
@@ -111,10 +149,18 @@ module Aptly
 
     def mirror_command(res)
       if mirror_exists?(res.mirror_name, res)
-        "aptly mirror edit#{with_installer(res.with_installer)}#{with_udebs(res.with_udebs)}#{architectures(res.architectures)}#{filter(res.filter)}#{filter_with_deps(res.filter_with_deps)}#{dep_follow_all_variants(res.dep_follow_all_variants)}#{dep_follow_recommends(res.dep_follow_recommends)}#{dep_follow_source(res.dep_follow_source)}#{dep_follow_suggests(res.dep_follow_suggests)}#{dep_verbose_resolve(res.dep_verbose_resolve)}#{ignore_signatures(res.ignore_signatures)} #{res.mirror_name}"
+        aptly_command('aptly', 'mirror', 'edit', *mirror_create_options(res), res.mirror_name)
       else
-        "aptly mirror create#{with_installer(res.with_installer)}#{with_udebs(res.with_udebs)}#{architectures(res.architectures)}#{filter(res.filter)}#{filter_with_deps(res.filter_with_deps)}#{dep_follow_all_variants(res.dep_follow_all_variants)}#{dep_follow_recommends(res.dep_follow_recommends)}#{dep_follow_source(res.dep_follow_source)}#{dep_follow_suggests(res.dep_follow_suggests)}#{dep_verbose_resolve(res.dep_verbose_resolve)}#{ignore_signatures(res.ignore_signatures)} #{res.mirror_name} #{res.uri} #{res.distribution} #{res.component}"
+        aptly_command('aptly', 'mirror', 'create', *mirror_create_options(res), res.mirror_name, res.uri, res.distribution, res.component)
       end
+    end
+
+    def mirror_update_command(res)
+      aptly_command('aptly', 'mirror', 'update', *mirror_update_options(res), res.mirror_name)
+    end
+
+    def mirror_drop_command(res)
+      aptly_command('aptly', 'mirror', 'drop', res.mirror_name)
     end
 
     def aptly_property(resource, property_name)

--- a/resources/mirror.rb
+++ b/resources/mirror.rb
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'shellwords'
+
 provides :aptly_mirror
 unified_mode true
 use '_partial/_common'
@@ -78,13 +80,17 @@ action :create do
     install_key(new_resource.keyid, new_resource.keyserver)
   end
 
+  platform_keyring = "/usr/share/keyrings/#{node['platform']}-archive-keyring.gpg"
+  trusted_keyring = "#{new_resource.root_dir}/.gnupg/trustedkeys.gpg"
+  platform_keyring_marker = "#{new_resource.root_dir}/.platform_keyring_imported"
+
   execute 'Import system platform keyring' do
-    command "gpg --no-default-keyring --keyring /usr/share/keyrings/#{node['platform']}-archive-keyring.gpg --export | gpg --no-default-keyring --keyring #{new_resource.root_dir}/.gnupg/trustedkeys.gpg --import && touch #{new_resource.root_dir}/.platform_keyring_imported"
+    command "gpg --no-default-keyring --keyring #{Shellwords.escape(platform_keyring)} --export | gpg --no-default-keyring --keyring #{Shellwords.escape(trusted_keyring)} --import && touch #{Shellwords.escape(platform_keyring_marker)}"
     user new_resource.user
     group new_resource.group
     retries 2
     environment resource_env
-    not_if { ::File.exist?("#{new_resource.root_dir}/.platform_keyring_imported") }
+    not_if { ::File.exist?(platform_keyring_marker) }
   end
 
   converge_if_changed do
@@ -100,7 +106,7 @@ end
 
 action :update do
   execute "Updating mirror - #{new_resource.mirror_name}" do
-    command "aptly mirror update#{dep_follow_all_variants(new_resource.dep_follow_all_variants)}#{dep_follow_recommends(new_resource.dep_follow_recommends)}#{dep_follow_source(new_resource.dep_follow_source)}#{dep_follow_suggests(new_resource.dep_follow_suggests)}#{dep_verbose_resolve(new_resource.dep_verbose_resolve)}#{ignore_checksums(new_resource.ignore_checksums)}#{ignore_signatures(new_resource.ignore_signatures)}#{download_limit(new_resource.download_limit)}#{max_tries(new_resource.max_tries)}#{skip_existing_packages(new_resource.skip_existing_packages)} #{new_resource.mirror_name}"
+    command mirror_update_command(new_resource)
     user new_resource.user
     group new_resource.group
     environment resource_env
@@ -112,7 +118,7 @@ end
 
 action :drop do
   execute "Droping mirror - #{new_resource.mirror_name}" do
-    command "aptly mirror drop #{new_resource.mirror_name}"
+    command mirror_drop_command(new_resource)
     user new_resource.user
     group new_resource.group
     environment resource_env
@@ -136,11 +142,12 @@ action_class do
     end
 
     execute "Import GPG key #{keyid}" do
-      command "gpg --no-default-keyring --keyring #{new_resource.root_dir}/.gnupg/trustedkeys.gpg --keyserver #{keyserver_uri(keyserver)} --recv-keys #{keyid}"
+      trusted_keyring = "#{new_resource.root_dir}/.gnupg/trustedkeys.gpg"
+      command Shellwords.join(['gpg', '--no-default-keyring', '--keyring', trusted_keyring, '--keyserver', keyserver_uri(keyserver), '--recv-keys', keyid])
       user new_resource.user
       group new_resource.group
       environment resource_env
-      not_if "gpg --no-default-keyring --keyring #{new_resource.root_dir}/.gnupg/trustedkeys.gpg --list-keys #{keyid}"
+      not_if { gpg_key_imported?(trusted_keyring, keyid) }
     end
   end
 
@@ -162,7 +169,7 @@ action_class do
     end
 
     execute "Import GPG key from #{keyfile}" do
-      command "gpg --no-default-keyring --keyring #{new_resource.root_dir}/.gnupg/trustedkeys.gpg --import #{Chef::Config['file_cache_path']}/#{keyfile}"
+      command Shellwords.join(['gpg', '--no-default-keyring', '--keyring', "#{new_resource.root_dir}/.gnupg/trustedkeys.gpg", '--import', "#{Chef::Config['file_cache_path']}/#{keyfile}"])
       user new_resource.user
       group new_resource.group
       environment resource_env
@@ -174,5 +181,12 @@ action_class do
       group new_resource.group
       action :create
     end
+  end
+
+  def gpg_key_imported?(trusted_keyring, keyid)
+    cmd = shell_out(Shellwords.join(['gpg', '--no-default-keyring', '--keyring', trusted_keyring, '--list-keys', keyid]),
+      user: new_resource.user,
+      environment: resource_env)
+    cmd.exitstatus == 0
   end
 end

--- a/resources/publish.rb
+++ b/resources/publish.rb
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'shellwords'
+
 provides :aptly_publish
 unified_mode true
 use '_partial/_common'
@@ -32,26 +34,21 @@ property :skip_signing,   [true, false], default: false
 
 action :create do
   components = new_resource.component.join(',')
-  endpoint = new_resource.endpoint.empty? ? '' : "#{new_resource.endpoint}:"
-  signing_options = publish_signing_options
 
   execute "Publish #{new_resource.type} - #{new_resource.publish_name}" do
-    command "aptly publish #{new_resource.type} -batch#{signing_options} -component='#{components}' #{architectures(new_resource.architectures)} -distribution='#{new_resource.distribution}' -- #{new_resource.publish_name} #{endpoint}#{new_resource.prefix}"
+    command aptly_command('aptly', 'publish', new_resource.type, '-batch', *publish_signing_options, "-component=#{components}", *publish_architecture_options, "-distribution=#{new_resource.distribution}", '--', new_resource.publish_name, publish_endpoint_prefix)
     user new_resource.user
     group new_resource.group
     environment resource_env
     sensitive !new_resource.skip_signing
     timeout new_resource.timeout
-    not_if %(aptly publish list | grep #{new_resource.publish_name})
+    not_if { publish_exists?(new_resource.publish_name) }
   end
 end
 
 action :switch do
-  endpoint = new_resource.endpoint.empty? ? '' : "#{new_resource.endpoint}:"
-  component = new_resource.component.empty? ? '' : "-component=#{new_resource.component.join(',')}"
-  signing_options = publish_signing_options
   execute "Switching distribution - #{new_resource.prefix}/#{new_resource.distribution} #{new_resource.publish_name}" do
-    command "aptly publish switch -batch#{signing_options} #{component} #{new_resource.distribution} #{endpoint}#{new_resource.prefix} #{new_resource.publish_name}"
+    command aptly_command('aptly', 'publish', 'switch', '-batch', *publish_signing_options, publish_component_option, new_resource.distribution, publish_endpoint_prefix, new_resource.publish_name)
     user new_resource.user
     group new_resource.group
     environment resource_env
@@ -61,11 +58,8 @@ action :switch do
 end
 
 action :update do
-  endpoint = new_resource.endpoint.empty? ? '' : "#{new_resource.endpoint}:"
-  signing_options = publish_signing_options
-
   execute "Updating distribution - #{new_resource.prefix} #{new_resource.publish_name}" do
-    command "aptly publish update -batch#{signing_options} #{new_resource.publish_name} #{endpoint}#{new_resource.prefix}"
+    command aptly_command('aptly', 'publish', 'update', '-batch', *publish_signing_options, new_resource.publish_name, publish_endpoint_prefix)
     user new_resource.user
     group new_resource.group
     environment resource_env
@@ -75,27 +69,50 @@ action :update do
 end
 
 action :drop do
-  endpoint = new_resource.endpoint.empty? ? '' : "#{new_resource.endpoint}:"
   prefix = new_resource.prefix.empty? ? './' : "#{new_resource.prefix}/"
 
   execute "Stop publishing - #{prefix}#{new_resource.publish_name}" do
-    command "aptly publish drop #{new_resource.publish_name} #{endpoint}#{new_resource.prefix}"
+    command aptly_command('aptly', 'publish', 'drop', new_resource.publish_name, publish_endpoint_prefix)
     user new_resource.user
     group new_resource.group
     environment resource_env
     timeout new_resource.timeout
-    only_if %(aptly publish list | grep #{new_resource.publish_name})
+    only_if { publish_exists?(new_resource.publish_name) }
   end
 end
 
 action_class do
-  def publish_signing_options
-    return ' -skip-signing' if new_resource.skip_signing
+  include ::Aptly::Helpers
 
-    " -passphrase='#{new_resource.gpg_passphrase}'"
+  def publish_signing_options
+    return ['-skip-signing'] if new_resource.skip_signing
+
+    ["-passphrase=#{new_resource.gpg_passphrase}"]
+  end
+
+  def publish_component_option
+    return if new_resource.component.empty?
+
+    "-component=#{new_resource.component.join(',')}"
+  end
+
+  def publish_architecture_options
+    return [] if new_resource.architectures.empty?
+
+    ['-architectures', new_resource.architectures.join(',')]
+  end
+
+  def publish_endpoint_prefix
+    endpoint = new_resource.endpoint.empty? ? '' : "#{new_resource.endpoint}:"
+    "#{endpoint}#{new_resource.prefix}"
   end
 
   def resource_env
     { 'HOME' => new_resource.root_dir, 'USER' => new_resource.user, 'TMPDIR' => new_resource.tmp_dir }
+  end
+
+  def publish_exists?(publish_name)
+    cmd = shell_out(aptly_command('aptly', 'publish', 'list'), user: new_resource.user, group: new_resource.group, environment: resource_env)
+    cmd.exitstatus == 0 && cmd.stdout.include?(publish_name)
   end
 end

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'shellwords'
+
 provides :aptly_repo
 unified_mode true
 use '_partial/_common'
@@ -31,26 +33,26 @@ property :package_query, String
 
 action :create do
   opts = ''
-  opts += " -comment='#{new_resource.comment}'" unless new_resource.comment.nil? || new_resource.comment.empty?
-  opts += " -component='#{new_resource.component}'" unless new_resource.component.nil? || new_resource.component.empty?
-  opts += " -distribution='#{new_resource.distribution}'" unless new_resource.distribution.nil? || new_resource.distribution.empty?
+  opts += " -comment=#{Shellwords.escape(new_resource.comment)}" unless new_resource.comment.nil? || new_resource.comment.empty?
+  opts += " -component=#{Shellwords.escape(new_resource.component)}" unless new_resource.component.nil? || new_resource.component.empty?
+  opts += " -distribution=#{Shellwords.escape(new_resource.distribution)}" unless new_resource.distribution.nil? || new_resource.distribution.empty?
 
   execute "Creating Repo - #{new_resource.repo_name}" do
-    command "aptly repo create#{opts} #{new_resource.repo_name}"
+    command "aptly repo create#{opts} #{Shellwords.escape(new_resource.repo_name)}"
     user new_resource.user
     group new_resource.group
     environment resource_env
-    not_if %(aptly repo list --raw | grep #{new_resource.repo_name})
+    not_if { repo_exists?(new_resource.repo_name) }
   end
 end
 
 action :drop do
   execute "Droping Repo - #{new_resource.repo_name}" do
-    command "aptly repo drop #{new_resource.repo_name}"
+    command "aptly repo drop #{Shellwords.escape(new_resource.repo_name)}"
     user new_resource.user
     group new_resource.group
     environment resource_env
-    only_if %(aptly repo list --raw | grep #{new_resource.repo_name})
+    only_if { repo_exists?(new_resource.repo_name) }
   end
 end
 
@@ -62,7 +64,7 @@ action :add do
   if new_resource.directory && !new_resource.file
     if ::Dir.exist?(new_resource.directory)
       execute "Adding packages from #{new_resource.directory}" do
-        command "aptly repo add#{opts} #{new_resource.repo_name} #{new_resource.directory}"
+        command "aptly repo add#{opts} #{Shellwords.escape(new_resource.repo_name)} #{Shellwords.escape(new_resource.directory)}"
         user new_resource.user
         group new_resource.group
         environment resource_env
@@ -75,11 +77,11 @@ action :add do
       pkg = ::File.basename(new_resource.file)
       pk = pkg.split('.').first
       execute "Adding Package - #{pkg}" do
-        command "aptly repo add#{opts} #{new_resource.repo_name} #{new_resource.file}"
+        command "aptly repo add#{opts} #{Shellwords.escape(new_resource.repo_name)} #{Shellwords.escape(new_resource.file)}"
         user new_resource.user
         group new_resource.group
         environment resource_env
-        not_if %(aptly repo show -with-packages #{new_resource.repo_name} | grep #{pk})
+        not_if { package_exists?(new_resource.repo_name, pk) }
       end
     else
       Chef::Log.info "#{new_resource.file} does not exist"
@@ -91,16 +93,28 @@ end
 
 action :remove do
   execute "Removing Package - #{new_resource.package_query}" do
-    command "aptly repo remove #{new_resource.repo_name} #{new_resource.package_query}"
+    command "aptly repo remove #{Shellwords.escape(new_resource.repo_name)} #{Shellwords.escape(new_resource.package_query)}"
     user new_resource.user
     group new_resource.group
     environment resource_env
-    only_if %(aptly repo show -with-packages #{new_resource.repo_name} | grep #{new_resource.package_query})
+    only_if { package_exists?(new_resource.repo_name, new_resource.package_query) }
   end
 end
 
 action_class do
+  include ::Aptly::Helpers
+
   def resource_env
     { 'HOME' => new_resource.root_dir, 'USER' => new_resource.user, 'TMPDIR' => new_resource.tmp_dir }
+  end
+
+  def repo_exists?(repo_name)
+    cmd = shell_out(aptly_command('aptly', 'repo', 'list', '--raw'), user: new_resource.user, group: new_resource.group, environment: resource_env)
+    cmd.exitstatus == 0 && cmd.stdout.lines.any? { |line| line.chomp == repo_name }
+  end
+
+  def package_exists?(repo_name, package_query)
+    cmd = shell_out(aptly_command('aptly', 'repo', 'show', '-with-packages', repo_name), user: new_resource.user, group: new_resource.group, environment: resource_env)
+    cmd.exitstatus == 0 && cmd.stdout.include?(package_query)
   end
 end

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -24,9 +24,7 @@ RSpec.describe Aptly::Helpers do
     before do
       # existing mirror config
       allow(subject).to receive(:mirror_exists?).and_call_original
-      allow(subject).to receive_shell_out('aptly mirror -raw list | grep ^ubuntu-precise-main$', stdout: 'ubuntu-precise-main')
-      # missing mirror config
-      allow(subject).to receive_shell_out('aptly mirror -raw list | grep ^missing-repo-mirror$', exitstatus: 1)
+      allow(subject).to receive_shell_out('aptly mirror -raw list', stdout: "ubuntu-precise-main\n")
     end
 
     context 'checks for existence of mirror' do
@@ -42,6 +40,7 @@ RSpec.describe Aptly::Helpers do
       let(:mirror) { 'missing-repo-mirror' }
 
       it 'missing-repo-mirror' do
+        allow(subject).to receive_shell_out('aptly mirror -raw list', stdout: '')
         expect(subject.mirror_exists?(mirror)).to eq false
         expect(subject.mirror_exists?(mirror)).not_to eq true
       end
@@ -52,10 +51,9 @@ RSpec.describe Aptly::Helpers do
     before do
       # existing mirror config
       allow(subject).to receive(:mirror_exists?).and_call_original
-      allow(subject).to receive_shell_out('aptly mirror -raw list | grep ^ubuntu-precise-main$', stdout: 'ubuntu-precise-main')
+      allow(subject).to receive_shell_out('aptly mirror -raw list', stdout: "ubuntu-precise-main\n")
       allow(subject).to receive_shell_out('aptly mirror show ubuntu-precise-main', stdout: mirror_show_after_create_stdout)
       # missing mirror config
-      allow(subject).to receive_shell_out('aptly mirror -raw list | grep ^missing-repo-mirror$', exitstatus: 1)
       allow(subject).to receive_shell_out('aptly mirror show missing-repo-mirror', exitstatus: 1)
     end
 
@@ -82,10 +80,9 @@ RSpec.describe Aptly::Helpers do
       # existing mirror config
       allow(subject).to receive(:mirror_exists?).and_call_original
       allow(subject).to receive(:mirror_info).and_call_original
-      allow(subject).to receive_shell_out('aptly mirror -raw list | grep ^ubuntu-precise-main$', stdout: 'ubuntu-precise-main')
+      allow(subject).to receive_shell_out('aptly mirror -raw list', stdout: "ubuntu-precise-main\n")
       allow(subject).to receive_shell_out('aptly mirror show ubuntu-precise-main', stdout: mirror_show_after_create_stdout)
       # missing mirror config
-      allow(subject).to receive_shell_out('aptly mirror -raw list | grep ^missing-repo-mirror$', exitstatus: 1)
       allow(subject).to receive_shell_out('aptly mirror show missing-repo-mirror', exitstatus: 1)
     end
 
@@ -157,9 +154,7 @@ RSpec.describe Aptly::Helpers do
       )
       # existing mirror config
       allow(subject).to receive(:mirror_exists?).and_call_original
-      allow(subject).to receive_shell_out('aptly mirror -raw list | grep ^ubuntu-precise-main$', stdout: 'ubuntu-precise-main')
-      # missing mirror config
-      allow(subject).to receive_shell_out('aptly mirror -raw list | grep ^missing-repo-mirror$', exitstatus: 1)
+      allow(subject).to receive_shell_out('aptly mirror -raw list', stdout: "ubuntu-precise-main\n")
     end
 
     context 'creates missing mirror' do
@@ -201,8 +196,8 @@ RSpec.describe Aptly::Helpers do
     context 'zip (<= 3.0)' do
       let(:filter_string) { 'zip (<= 3.0)' }
 
-      it "returns -filter 'zip (<= 3.0)' argument" do
-        expect(subject.filter(filter_string)).to eq " -filter 'zip (<= 3.0)'"
+      it 'returns escaped -filter argument' do
+        expect(subject.filter(filter_string)).to eq ' -filter zip\ \(\<\=\ 3.0\)'
       end
     end
 

--- a/spec/unit/resources/mirror2_spec.rb
+++ b/spec/unit/resources/mirror2_spec.rb
@@ -32,15 +32,15 @@ platforms.each do |platform, version|
     end
 
     stubs_for_provider('aptly_mirror[ubuntu-precise-main]') do |provider|
-      allow(provider).to receive_shell_out('aptly mirror -raw list | grep ^ubuntu-precise-main$', { user: 'aptly', timeout: 3600.0, environment: { 'HOME' => '/opt/aptly', 'USER' => 'aptly' } }, stdout: '', stderr: '', exitstatus: 1)
+      allow(provider).to receive_shell_out('aptly mirror -raw list', stdout: '', stderr: '', exitstatus: 1)
     end
 
     stubs_for_resource('aptly_mirror[ubuntu-precise-main]') do |resource|
-      allow(resource).to receive_shell_out('aptly mirror -raw list | grep ^ubuntu-precise-main$', { user: 'aptly', environment: { 'HOME' => '/opt/aptly', 'TMPDIR' => '/tmp', 'USER' => 'aptly' } }, stdout: '', stderr: '', exitstatus: 1)
+      allow(resource).to receive_shell_out('aptly mirror -raw list', stdout: '', stderr: '', exitstatus: 1)
     end
 
     stubs_for_resource do |resource|
-      allow(resource).to receive_shell_out('aptly mirror -raw list | grep ^ubuntu-precise-main$', { user: 'aptly', environment: { 'HOME' => '/opt/aptly', 'TMPDIR' => '/tmp', 'USER' => 'aptly' } }, stdout: 'ubuntu-precise-main')
+      allow(resource).to receive_shell_out('aptly mirror -raw list', stdout: "ubuntu-precise-main\n")
     end
 
     context 'Create action test with keyfile' do

--- a/spec/unit/resources/mirror_spec.rb
+++ b/spec/unit/resources/mirror_spec.rb
@@ -35,20 +35,23 @@ platforms.each do |platform, version|
     end
 
     stubs_for_provider('aptly_mirror[ubuntu-precise-main]') do |provider|
-      allow(provider).to receive_shell_out('aptly mirror -raw list | grep ^ubuntu-precise-main$', { user: 'aptly', timeout: 3600.0, environment: { 'HOME' => '/opt/aptly', 'USER' => 'aptly' } }, stdout: '', stderr: '', exitstatus: 1)
+      allow(provider).to receive_shell_out('aptly mirror -raw list', stdout: '', stderr: '', exitstatus: 1)
+      allow(provider).to receive_shell_out('gpg --no-default-keyring --keyring /opt/aptly/.gnupg/trustedkeys.gpg --list-keys 437D05B5', exitstatus: 1)
     end
 
     stubs_for_resource('aptly_mirror[ubuntu-precise-main]') do |resource|
-      allow(resource).to receive_shell_out('aptly mirror -raw list | grep ^ubuntu-precise-main$', { user: 'aptly', environment: { 'HOME' => '/opt/aptly', 'TMPDIR' => '/tmp', 'USER' => 'aptly' } }, stdout: '', stderr: '', exitstatus: 1)
+      allow(resource).to receive_shell_out('aptly mirror -raw list', stdout: '', stderr: '', exitstatus: 1)
+      allow(resource).to receive_shell_out('gpg --no-default-keyring --keyring /opt/aptly/.gnupg/trustedkeys.gpg --list-keys 437D05B5', exitstatus: 1)
     end
 
     stubs_for_resource do |resource|
-      allow(resource).to receive_shell_out('aptly mirror -raw list | grep ^ubuntu-precise-main$', { user: 'aptly', environment: { 'HOME' => '/opt/aptly', 'TMPDIR' => '/tmp', 'USER' => 'aptly' } }, stdout: 'ubuntu-precise-main')
+      allow(resource).to receive_shell_out('aptly mirror -raw list', stdout: "ubuntu-precise-main\n")
+      allow(resource).to receive_shell_out('gpg --no-default-keyring --keyring /opt/aptly/.gnupg/trustedkeys.gpg --list-keys 437D05B5', exitstatus: 1)
     end
 
     context 'Create action test' do
       stubs_for_resource('execute[Creating mirror - ubuntu-precise-main]') do |resource|
-        allow(resource).to receive_shell_out('aptly mirror -raw list | grep ^ubuntu-precise-main$', { user: 'aptly', environment: { 'HOME' => '/opt/aptly', 'USER' => 'aptly' } }, stdout: '', stderr: '', exitstatus: 1)
+        allow(resource).to receive_shell_out('aptly mirror -raw list', stdout: '', stderr: '', exitstatus: 1)
         allow(resource).to receive_shell_out('aptly mirror show ubuntu-precise-main', exitstatus: 1)
       end
 

--- a/spec/unit/resources/publish_spec.rb
+++ b/spec/unit/resources/publish_spec.rb
@@ -45,9 +45,10 @@ platforms.each do |platform, version|
     # end
 
     context 'Create and Update action' do
-      before do
-        stub_command('aptly publish list | grep my_repo').and_return(false)
+      stubs_for_provider('aptly_publish[my_repo]') do |provider|
+        allow(provider).to receive_shell_out('aptly publish list', stdout: '')
       end
+
       it 'Run the custom resources' do
         expect(chef_run).to create_aptly_publish('my_repo')
         expect(chef_run).to update_aptly_publish('my_repo').with(prefix: 'foo')
@@ -59,9 +60,10 @@ platforms.each do |platform, version|
     end
 
     context 'Drop action' do
-      before do
-        stub_command('aptly publish list | grep my_repo').and_return(true)
+      stubs_for_provider('aptly_publish[my_repo]') do |provider|
+        allow(provider).to receive_shell_out('aptly publish list', stdout: "my_repo\n")
       end
+
       it 'Run the custom resources' do
         expect(chef_run).to drop_aptly_publish('my_repo')
       end

--- a/spec/unit/resources/repo2_spec.rb
+++ b/spec/unit/resources/repo2_spec.rb
@@ -38,10 +38,11 @@ platforms.each do |platform, version|
     # end
 
     context 'Add action with directory' do
-      before do
-        stub_command('aptly repo list --raw | grep my_repo').and_return(false)
-        stub_command('aptly repo show -with-packages my_repo | grep hosts').and_return(false)
+      stubs_for_provider('aptly_repo[my_repo]') do |provider|
+        allow(provider).to receive_shell_out('aptly repo list --raw', stdout: '')
+        allow(provider).to receive_shell_out('aptly repo show -with-packages my_repo', stdout: '')
       end
+
       it 'Run the custom resources' do
         expect(chef_run).to add_aptly_repo('my_repo').with(directory: '/tmp')
       end

--- a/spec/unit/resources/repo_spec.rb
+++ b/spec/unit/resources/repo_spec.rb
@@ -59,10 +59,11 @@ platforms.each do |platform, version|
     # end
 
     context 'Create action test' do
-      before do
-        stub_command('aptly repo list --raw | grep my_repo').and_return(false)
-        stub_command('aptly repo show -with-packages my_repo | grep hosts').and_return(false)
+      stubs_for_provider('aptly_repo[my_repo]') do |provider|
+        allow(provider).to receive_shell_out('aptly repo list --raw', stdout: '')
+        allow(provider).to receive_shell_out('aptly repo show -with-packages my_repo', stdout: '')
       end
+
       it 'Run the custom resources' do
         expect(chef_run).to create_aptly_repo('my_repo').with(comment: 'A repository of packages', component: 'main', distribution: 'Ubuntu')
       end
@@ -72,10 +73,11 @@ platforms.each do |platform, version|
     end
 
     context 'Add action with file' do
-      before do
-        stub_command('aptly repo list --raw | grep my_repo').and_return(true)
-        stub_command('aptly repo show -with-packages my_repo | grep hosts').and_return(false)
+      stubs_for_provider('aptly_repo[my_repo]') do |provider|
+        allow(provider).to receive_shell_out('aptly repo list --raw', stdout: "my_repo\n")
+        allow(provider).to receive_shell_out('aptly repo show -with-packages my_repo', stdout: '')
       end
+
       it 'Run the custom resources' do
         expect(chef_run).to add_aptly_repo('my_repo').with(file: '/etc/hosts')
       end
@@ -85,10 +87,11 @@ platforms.each do |platform, version|
     end
 
     context 'Drop and remove action' do
-      before do
-        stub_command('aptly repo list --raw | grep my_repo').and_return(true)
-        stub_command('aptly repo show -with-packages my_repo | grep hosts').and_return(true)
+      stubs_for_provider('aptly_repo[my_repo]') do |provider|
+        allow(provider).to receive_shell_out('aptly repo list --raw', stdout: "my_repo\n")
+        allow(provider).to receive_shell_out('aptly repo show -with-packages my_repo', stdout: "hosts\n")
       end
+
       it 'Run the custom resources' do
         expect(chef_run).to drop_aptly_repo('my_repo')
         expect(chef_run).to remove_aptly_repo('my_repo').with(package_query: 'hosts')


### PR DESCRIPTION
## Summary
- Escape aptly command arguments with Shellwords-backed builders
- Replace grep guards with Ruby-native existence checks
- Harden mirror, repo, publish, and GPG command construction

## Verification
- cookstyle libraries/helpers.rb resources/repo.rb resources/publish.rb resources/mirror.rb spec/libraries/helpers_spec.rb spec/unit/resources/mirror_spec.rb spec/unit/resources/mirror2_spec.rb spec/unit/resources/repo_spec.rb spec/unit/resources/repo2_spec.rb spec/unit/resources/publish_spec.rb
- /opt/chef-workstation/embedded/bin/rspec spec/libraries/helpers_spec.rb spec/unit/resources/mirror_spec.rb spec/unit/resources/mirror2_spec.rb spec/unit/resources/repo_spec.rb spec/unit/resources/repo2_spec.rb spec/unit/resources/publish_spec.rb --format progress
- pre-commit hook: cookstyle, markdownlint, rspec, yamllint