### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# Aptly Cookbook Limitations
+# AGENTS.md
+
+## Cookbook Purpose
+
+Installs/Configures aptly
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 - Aptly upstream publishes packages for Debian `bullseye`, `bookworm`, and `trixie`, plus Ubuntu `jammy` and `noble`.
 - Debian 12 remains supported through June 10, 2026 in standard Debian security support and through June 30, 2028 in Debian LTS.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Installs/Configures aptly
 
 ## Known Limitations
 
-- Aptly upstream publishes packages for Debian `bullseye`, `bookworm`, and `trixie`, plus Ubuntu `jammy` and `noble`.
-- Debian 12 remains supported through June 10, 2026 in standard Debian security support and through June 30, 2028 in Debian LTS.
-- Debian 13 is now current and supported by Aptly upstream, so it is included in Kitchen and CI.
-- The cookbook support matrix is limited to Debian 12, Debian 13, Ubuntu 22.04, and Ubuntu 24.04.
+* Aptly upstream publishes packages for Debian `bullseye`, `bookworm`, and `trixie`, plus Ubuntu `jammy` and `noble`.
+* Debian 12 remains supported through June 10, 2026 in standard Debian security support and through June 30, 2028 in Debian LTS.
+* Debian 13 is now current and supported by Aptly upstream, so it is included in Kitchen and CI.
+* The cookbook support matrix is limited to Debian 12, Debian 13, Ubuntu 22.04, and Ubuntu 24.04.

--- a/Berksfile
+++ b/Berksfile
@@ -1,8 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'aptly_spec', path: 'spec/fixtures/cookbooks/aptly_spec'
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+name 'aptly'
+
+run_list 'recipe[test::setup]', 'recipe[test::default]'
+
+cookbook 'aptly', path: '.'
+cookbook 'gpg', git: 'https://github.com/sous-chefs/gpg.git', branch: 'main'
+cookbook 'yum-epel', git: 'https://github.com/sous-chefs/yum-epel.git', branch: 'main'
+cookbook 'aptly_spec', path: './spec/fixtures/cookbooks/aptly_spec'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./spec/fixtures/cookbooks/aptly_spec/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'aptly_spec::' + recipe_name
+end
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/chefignore
+++ b/chefignore
@@ -85,8 +85,6 @@ test/*
 
 # Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/spec/fixtures/cookbooks/aptly_spec/.gitignore
+++ b/spec/fixtures/cookbooks/aptly_spec/.gitignore
@@ -17,6 +17,5 @@ bin/*
 .kitchen.local.yml
 
 # Chef
-Berksfile.lock
 .zero-knife.rb
 Policyfile.lock.json

--- a/spec/fixtures/cookbooks/aptly_spec/chefignore
+++ b/spec/fixtures/cookbooks/aptly_spec/chefignore
@@ -79,7 +79,6 @@ Rakefile
 # Berkshelf #
 #############
 Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 # require 'chefspec/policyfile'
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update CI/Copilot workflow references to current sous-chefs workflow/action versions
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- /opt/chef-workstation/embedded/bin/rspec --format progress
- kitchen list